### PR TITLE
fix(labeler): change bug label to fix for consistency with PR types

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,6 @@
 feature:
   - head-branch: ['^feature/']
-bug:
+fix:
   - head-branch: ['^fix/', '^bugfix/', '^hotfix/']
 documentation:
   - head-branch: ['^documentation/']


### PR DESCRIPTION
## Summary
This PR fixes the inconsistency where `fix/*` branches were assigned the `bug` label instead of the `fix` label to match the PR title type defined in CONTRIBUTING.md.

## Changes
- Changed `bug:` to `fix:` in `.github/labeler.yml` for `fix/`, `bugfix/`, and `hotfix/` branches
- Ensures consistency between PR title types and auto-assigned labels

## Impact
- `fix/*` branches will now receive the `fix` label instead of `bug`
- Both `fix` and `bug` labels are still accepted by release-drafter.yml, so this is a non-breaking change
- Improves consistency and reduces confusion for contributors

## Test Plan
- Verify that the labeler workflow still functions correctly
- Confirm that fix/* branches receive the fix label

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)