### PR TITLE
fix(labeler): remove undocumented pipeline/ branch prefix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,7 @@ performance:
 test:
   - head-branch: ['^test/']
 ci:
-  - head-branch: ['^ci/', '^pipeline/']
+  - head-branch: ['^ci/']
 chore:
   - head-branch: ['^chore/', '^build/']
 revert:


### PR DESCRIPTION
## Summary
This PR removes the undocumented `pipeline/` branch prefix support from labeler.yml to maintain consistency with CONTRIBUTING.md, which only documents `ci/xxx` as the branch naming pattern for CI changes.

## Changes
- Removed `^pipeline/` from ci label configuration in `.github/labeler.yml`
- Standardizes on `ci/` prefix only as documented in CONTRIBUTING.md:82

## Current State
- CONTRIBUTING.md:82 documents only `ci/xxx` branch naming
- labeler.yml:14 supported both `^ci/` and `^pipeline/`
- This created an undocumented branch naming option

## Impact
- Only `ci/*` branches will receive the ci label going forward
- Eliminates confusion from undocumented branch naming pattern
- Contributors can rely solely on CONTRIBUTING.md for all branch naming conventions

## Alternative Considered
We could have documented `pipeline/` in CONTRIBUTING.md instead, but removing it maintains simplicity and consistency with a single, clear naming pattern for CI-related changes.

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)