### PR TITLE
fix(release-drafter): change default from patch to null to honor 'None' types

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,7 +39,7 @@ version-resolver:
       - 'fix'
       - 'bug'
       - 'perf'
-  default: patch
+  default: null
 template: |
   ## Changes
   $CHANGES


### PR DESCRIPTION
## Summary
This PR fixes a **critical bug** where the `default: patch` setting caused PRs with types marked as "Version Impact: None" in CONTRIBUTING.md to unintentionally increase the patch version, violating the documented Semantic Versioning policy.

## Problem
- CONTRIBUTING.md:76-82 defines 7 types with "SemVer Impact: None"
- release-drafter.yml:42 has `default: patch`
- Result: These PRs incorrectly bump patch version

Example:
- Merge a `documentation:` PR
- Expected: Version stays at 1.0.0 (as documented)
- Actual: Version bumps to 1.0.1 (violates policy)

## Changes
- Changed `default: patch` to `default: null` in `.github/release-drafter.yml`

## Impact
PRs with the following types will now **correctly not bump version**:
- `documentation` (CONTRIBUTING.md:76)
- `style` (CONTRIBUTING.md:77)
- `refactor` (CONTRIBUTING.md:78)
- `test` (CONTRIBUTING.md:79)
- `build` (CONTRIBUTING.md:80)
- `ci` (CONTRIBUTING.md:81)
- `chore` (CONTRIBUTING.md:82)

**Only PRs with explicit labels will bump versions:**
- `major` label → Major version (x.0.0)
- `feature`/`feat` labels → Minor version (0.x.0)
- `fix`/`bug`/`perf` labels → Patch version (0.0.x)

## Priority
🔴 **HIGH** - This directly violates documented SemVer policy and affects release versioning

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)