### PR TITLE
fix(release-drafter): remove remaining 'bug' label references to complete standardization

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,7 +7,6 @@ categories:
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
-      - 'bug'
   - title: '⚡️ Performance Improvements'
     labels:
       - 'performance'
@@ -36,7 +35,6 @@ version-resolver:
   patch:
     labels:
       - 'fix'
-      - 'bug'
       - 'performance'
       - 'revert'
   default: null


### PR DESCRIPTION
## Summary
- Complete the standardization effort from issues #9 and #21
- Remove vestigial 'bug' label references from release-drafter.yml
- Eliminate dead configuration that expected labels never created by labeler.yml

## Changes
- Remove 'bug' from Bug Fixes category labels
- Remove 'bug' from patch version resolver labels  

## Background
Following the fixes in #9 (labeler.yml) and #21 (aliases), release-drafter.yml still contained 'bug' label references that could never be matched since labeler.yml only assigns 'fix' labels to fix/* branches.

## Test Plan
- [x] Verify release-drafter.yml syntax is valid
- [x] Confirm only 'fix' labels are now referenced
- [x] Check that fix/* branches will properly trigger patch version bumps

Closes #23