### PR TITLE
fix: remove 'bug' label references from templates and configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report (バグ報告)
 about: バグや不具合の報告に使います
 title: ""
-labels: bug
+labels: ""
 assignees: ""
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ The next version is determined based on labels assigned to PRs.
 | :--- | :--- | :--- |
 | `major` | 🚨 **Major** (x.0.0) | **Automatically assigned when PR title contains `!`** |
 | `feature` | 🚀 **Minor** (0.x.0) | Auto-assigned from `feature/*` branches |
-| `fix`, `bug`, `performance`, `revert` | 🐛 **Patch** (0.0.x) | Auto-assigned from `fix/*`, `performance/*`, `revert/*` branches, etc. |
+| `fix`, `performance`, `revert` | 🐛 **Patch** (0.0.x) | Auto-assigned from `fix/*`, `performance/*`, `revert/*` branches |
 | Others (`documentation`, `chore`, etc.) | None | Version number does not increase |
 
 ### Release Procedure


### PR DESCRIPTION
## Summary
- Removed 'bug' label from bug report template
- Removed 'bug' from Label to Version Mapping table in CONTRIBUTING.md

## Test plan
- Verify bug report template no longer assigns 'bug' label
- Verify documentation table accurately reflects configured labels

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)