### PR TITLE
fix: remove bugfix/ and hotfix/ branch patterns from labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,7 @@
 feature:
   - head-branch: ['^feature/']
 fix:
-  - head-branch: ['^fix/', '^bugfix/', '^hotfix/']
+  - head-branch: ['^fix/']
 documentation:
   - head-branch: ['^documentation/']
 refactor:


### PR DESCRIPTION
## Summary
- Removed 'bugfix/' and 'hotfix/' patterns from labeler.yml
- Keep only the documented 'fix/' pattern

## Test plan
- Verify labeler only accepts 'fix/' branches as documented in CONTRIBUTING.md
- Confirm consistency between documentation and automation

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)