### PR TITLE
fix(labeler): remove undocumented 'pipeline/' branch prefix

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -11,7 +11,7 @@ performance:
 test:
   - head-branch: ['^test/']
 ci:
-  - head-branch: ['^ci/', '^pipeline/']
+  - head-branch: ['^ci/']
 build:
   - head-branch: ['^build/']
 chore:


### PR DESCRIPTION
## Related Issue
- Closes #36

## Changes
- Removed the `pipeline/` prefix from `.github/labeler.yml` ci label configuration
- Now only the documented `ci/` prefix is accepted

## Test Steps
1. Verify that the labeler.yml only includes the `ci/` prefix
2. Confirm this matches the documentation in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)