### PR TITLE
fix(docs): standardize on 'Closes #' pattern only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Develop locally. Since changes will be squash merged, commit messages during wor
 ### Step 4: Create a Pull Request (PR)
 Create a PR on GitHub.
 * **Title**: Must strictly follow **[Naming Convention](#3-naming-convention-and-semver-conventional-commits)** (checked by CI).
-* **Body**: Include `Closes #123` or `Fixes #45` to link to the Issue. Describe changes, screenshots, and test methods.
+* **Body**: Include `Closes #123` to link to the Issue. Describe changes, screenshots, and test methods.
 * **Labels**: Automatically assigned based on branch name.
     * ⚠️ **For breaking changes**: The `major` label is automatically assigned when the PR title contains `!`.
 


### PR DESCRIPTION
## Related Issue
- Closes #37

## Changes
- Removed reference to `Fixes #45` from CONTRIBUTING.md
- Now only `Closes #123` pattern is documented for linking PRs to issues
- This aligns with the PR template which only shows `Closes #`

## Test Steps
1. Verify CONTRIBUTING.md no longer mentions `Fixes #`
2. Confirm consistency with `.github/pull_request_template.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)