### PR TITLE
fix(docs): remove merge responsibility specification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Create a PR on GitHub.
 ### Step 5: Review & Merge
 * CI (Lint PR, Tests) must pass.
 * Reviewer approval is required.
-* **Merge responsibility**: The PR creator should merge. Select "Squash and Merge" and **verify that the commit message matches the PR title**.
+* Select "Squash and Merge" and **verify that the commit message matches the PR title**.
 
 ### Step 6: Post-Merge Process
 * **Issue**: Automatically closed if `Closes #xxx` is included.


### PR DESCRIPTION
## Related Issue
- Closes #38

## Changes
- Removed the line "**Merge responsibility**: The PR creator should merge." from CONTRIBUTING.md
- Merge responsibility is now left unspecified, allowing teams flexibility in their workflows

## Test Steps
1. Verify the merge responsibility line has been removed
2. Confirm Step 5 still contains other important merge requirements (CI passing, reviewer approval, squash and merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)