### PR TITLE
documentation: simplify breaking changes section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,21 +82,14 @@ Pull Request titles must follow the **Conventional Commits** format.
 | **chore** | Other miscellaneous changes | None | `chore/xxx` |
 
 ### ⚠️ Breaking Changes (Major Version)
-For changes that break backward compatibility, follow both steps:
+For changes that break backward compatibility, add `!` after the Type in the PR title. The `major` label will be automatically assigned.
 
-1. Add `!` after the Type in the PR title
-2. Include `BREAKING CHANGE: details` in the PR body footer
-
-The `major` label will be automatically assigned based on the `!` in the PR title.
-
-**Complete example:**
+**Example:**
 ```
 Title: feature!: migrate REST API to GraphQL
 
 Body:
 This PR migrates the entire API from REST to GraphQL.
-
-BREAKING CHANGE: All REST endpoints have been removed. Clients must migrate to GraphQL queries.
 
 Closes #123
 ```


### PR DESCRIPTION
## Related Issue
- Closes #42

## Changes
- Removed the requirement to include `BREAKING CHANGE: details` in PR body footer
- Simplified breaking changes section to single-step instruction: add `!` after the Type in PR title
- Updated example PR to remove `BREAKING CHANGE:` line from body
- Ensured consistency with actual automation behavior (auto-label-major.yml only checks title)

## Test Steps
- Review the updated CONTRIBUTING.md section on breaking changes (lines 84-96)
- Verify the instruction is clear and matches the automation
- Confirm no conflicts with other sections

## Screenshots (Optional)
N/A - documentation change

## Review Points (Optional)
- Does the simplified instruction make the guideline clearer?
- Is the example now more straightforward?

🤖 Generated with [Claude Code](https://claude.com/claude-code)