### PR TITLE
documentation: clarify breaking change syntax

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Pull Request titles must follow the **Conventional Commits** format.
 | **chore** | Other miscellaneous changes | None | `chore/xxx` |
 
 ### ⚠️ Breaking Changes (Major Version)
-For changes that break backward compatibility, add `!` after the Type in the PR title. The `major` label will be automatically assigned.
+For changes that break backward compatibility, add `!` before the colon (after type or scope if present) in the PR title. The `major` label will be automatically assigned.
 
 **Example:**
 ```


### PR DESCRIPTION
## Related Issue
- Closes #44

## Changes
Updated CONTRIBUTING.md line 85 to clarify that the breaking change marker `!` should be placed "before the colon (after type or scope if present)" instead of the previous ambiguous wording "after the Type".

This makes it clearer that:
- Without scope: `feature!: description`
- With scope: `feature(scope)!: description`

The change aligns the documentation with the actual implementation in auto-label-major.yml which correctly handles both patterns.

## Test Steps
- Review the updated wording in CONTRIBUTING.md:85
- Verify it matches the Conventional Commits specification
- Confirm it aligns with the workflow implementation