### PR TITLE
documentation: add curl-based installation method to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ A reusable coding guideline repository that provides standardized development pr
 
 ## Quick Start
 
+Run the following command from your project root:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/IshitaTakeshi/CodingGuideline/main/setup.sh | bash
+```
+
+Alternatively, you can download and run the script manually:
+
 1. Download the setup script from the [GitHub repository](https://github.com/IshitaTakeshi/CodingGuideline)
 2. Run the script from your project root:
 


### PR DESCRIPTION
## Summary
Adds a convenient one-liner installation method using curl to fetch and execute setup.sh directly from the repository.

## Changes
- Added curl-based installation as the primary method in Quick Start section
- Kept existing manual download method as an alternative
- Uses `curl -fsSL` flags for proper error handling
- Fetches from main branch (stable due to CI checks)

## Test Plan
- [x] Verified README formatting
- [x] Confirmed curl command syntax is correct

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)