### PR TITLE
feature: add strict Python coding guideline

### DIFF
--- a/PYTHON.md
+++ b/PYTHON.md
@@ -1,0 +1,121 @@
+# Coding Standards & Guidelines
+
+> **Philosophy:** "Pure, Atomic, Trivial."
+> Every component must be small enough to be understood at a glance. Complexity is managed through composition, not indentation.
+
+## 1. Structure & Size Limits (Strict)
+
+We adhere to **Object Calisthenics** rules to force modularity.
+
+| Scope | Max Size (excluding comments/docstrings) |
+| :--- | :--- |
+| **File** | **100 lines** |
+| **Class** | **50 lines** |
+| **Function** | **15 lines** |
+
+* **File Sizing:** If a file exceeds 100 lines, it must be split. A file should contain only one class or a small set of tightly coupled functions.
+* **Function Sizing:** The 15-line limit is absolute.
+    * *Exceptions:* None. Even `try-except` blocks must be concise. If error handling is complex, delegate the logic inside the `try` block to a separate private function.
+
+## 2. Control Flow: The "No Else" Rule
+
+**The `else` keyword is forbidden.** Use Guard Clauses (Early Returns) instead.
+
+**Incorrect:**
+```python
+def calculate_status(value: int) -> str:
+    if value > 10:
+        return "High"
+    else:
+        return "Low"
+
+```
+
+**Correct:**
+
+```python
+def calculate_status(value: int) -> str:
+    if value > 10:
+        return "High"
+    return "Low"
+
+```
+
+## 3. Naming Conventions
+
+* **Style:** Follow PEP8 (Snake case for functions/variables, PascalCase for classes).
+* **Zero Tolerance for Abbreviations:** Names must be fully descriptive. Ambiguity is technical debt.
+
+| Forbidden | Required Replacement |
+| --- | --- |
+| `idx`, `i` | `index`, `sequence_index` |
+| `ctx` | `context` |
+| `repo` | `repository` |
+| `val` | `value` |
+| `params` | `parameters` |
+| `func` | `function` |
+
+## 4. Type Safety
+
+* **Strict Mode:** All code must pass `mypy --strict`.
+* **No `Any`:** The use of `Any` is forbidden. If a type is truly dynamic, use `TypeVar` or specific `Protocol`.
+* **Signatures:** Every function (public or private) must have type hints.
+
+## 5. Documentation
+
+* **Format:** Sphinx (ReStructuredText).
+* **Requirement:** Mandatory docstrings for all **Public** Modules, Classes, and Functions.
+* **Content:** Do not repeat type information in the docstring (the type hint is the source of truth). Focus on the *purpose* and *behavior*.
+
+```python
+def connect_to_database(connection_string: str) -> None:
+    """
+    Establishes the initial connection pool to the database.
+
+    Raises:
+        ConnectionError: If the remote host is unreachable.
+    """
+    ...
+
+```
+
+## 6. Imports
+
+* **Sorting:** Automated via Ruff/Isort.
+* **Unused Imports:** Strictly forbidden. The build will fail if detected.
+
+## 7. Tooling
+
+This repository provides configuration files for automated enforcement.
+
+### Ruff (Linter & Formatter)
+
+Derivative repositories can extend the ruff configuration:
+
+```toml
+# In your pyproject.toml
+[tool.ruff]
+extend = ".coding-guideline/ruff.toml"
+
+# Or in a standalone ruff.toml
+extend = ".coding-guideline/ruff.toml"
+```
+
+### MyPy (Type Checker)
+
+MyPy does not support configuration inheritance. Copy the settings from [`mypy.toml`](mypy.toml) to your project's `pyproject.toml`:
+
+```toml
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+disallow_any_explicit = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+```

--- a/mypy.toml
+++ b/mypy.toml
@@ -1,0 +1,16 @@
+# Strict Python MyPy Configuration
+# MyPy does not support "extend", so copy these settings to your project's
+# pyproject.toml under [tool.mypy] or to a mypy.ini file.
+
+[mypy]
+python_version = "3.10"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+# Disallow 'Any' entirely to force explicit types
+disallow_any_explicit = true
+
+[mypy-tests.*]
+disallow_untyped_defs = false

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,49 @@
+# Strict Python Ruff Configuration
+# Derivative repositories can extend this with:
+#   extend = ".coding-guideline/ruff.toml"
+
+# Target Python version
+target-version = "py310"
+
+# Line length
+line-length = 88
+
+[lint]
+# Enable strict rule sets
+select = [
+    "E",    # pycodestyle errors
+    "F",    # Pyflakes
+    "I",    # isort (Import sorting)
+    "N",    # pep8-naming
+    "UP",   # pyupgrade (Modernize syntax)
+    "B",    # flake8-bugbear (Likely bugs)
+    "A",    # flake8-builtins (Don't shadow builtins)
+    "C4",   # flake8-comprehensions
+    "RET",  # flake8-return (Enforces "No Else" / Early Return)
+    "SIM",  # flake8-simplify
+    "TCH",  # flake8-type-checking (Move imports to type-checking blocks)
+    "PL",   # Pylint (Complexity & standard rules)
+    "RUF",  # Ruff-specific rules (Unused imports, etc.)
+]
+
+ignore = [
+    "PLR2004", # Magic values comparison (sometimes necessary in math SDKs)
+]
+
+[lint.pylint]
+# Approx proxies for strict line limits:
+# 15 lines ~ 7-10 statements
+max-statements = 10
+# 50 lines class ~ 7 public methods + 3-4 attributes
+max-public-methods = 7
+# No branches allowed basically means very low complexity
+max-branches = 4
+
+[lint.mccabe]
+# Cyclomatic complexity. Keep it extremely low to force atomicity.
+max-complexity = 4
+
+[lint.pep8-naming]
+# Enforce standard naming, but "No Abbreviations" relies on human review
+# or a custom dictionary plugin.
+classmethod-decorators = ["classmethod"]


### PR DESCRIPTION
## Related Issue

Closes #62

## Context

This repository provides process guidelines (PR templates, issue templates, contribution rules) but lacks language-specific coding standards. Python developers adopting this guideline need strict, enforceable rules to maintain modular, readable code.

## Changes

- **`PYTHON.md`**: Documentation covering 7 sections—structure limits, control flow (no else), naming (no abbreviations), type safety (mypy --strict), documentation (Sphinx), imports, and tooling instructions
- **`ruff.toml`**: Standalone Ruff configuration with strict rules (RET for early returns, PL for complexity limits, I for import sorting). Derivative repos can extend via `extend = ".coding-guideline/ruff.toml"`
- **`mypy.toml`**: Strict MyPy configuration reference. Since MyPy doesn't support inheritance, users copy these settings.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Test Steps

1. Review `PYTHON.md` for clarity and completeness
2. Verify `ruff.toml` is valid: `ruff check --config ruff.toml --help`
3. Verify `mypy.toml` syntax is valid INI format
4. Test extension in a derivative repo:
   ```toml
   # In derivative repo's pyproject.toml
   [tool.ruff]
   extend = ".coding-guideline/ruff.toml"
   ```

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] My PR title follows the Conventional Commits format
- [x] I have added documentation for new features
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)