### PR TITLE
fix: update workflow to use renamed issue template files

### DIFF
--- a/.github/workflows/test-setup-script.yml
+++ b/.github/workflows/test-setup-script.yml
@@ -75,12 +75,12 @@ jobs:
       - name: Verify issue templates were copied
         working-directory: /tmp/test-project
         run: |
-          if [ ! -f ".github/ISSUE_TEMPLATE/bug_report.md" ]; then
-            echo "ERROR: bug_report.md not found"
+          if [ ! -f ".github/ISSUE_TEMPLATE/fix.md" ]; then
+            echo "ERROR: fix.md not found"
             exit 1
           fi
-          if [ ! -f ".github/ISSUE_TEMPLATE/feature_request.md" ]; then
-            echo "ERROR: feature_request.md not found"
+          if [ ! -f ".github/ISSUE_TEMPLATE/feature.md" ]; then
+            echo "ERROR: feature.md not found"
             exit 1
           fi
           echo "✓ Issue templates copied successfully"
@@ -150,8 +150,8 @@ jobs:
             ".github/workflows/check-pr-title.yml"
             ".github/workflows/labeler.yml"
             ".github/workflows/release-drafter.yml"
-            ".github/ISSUE_TEMPLATE/bug_report.md"
-            ".github/ISSUE_TEMPLATE/feature_request.md"
+            ".github/ISSUE_TEMPLATE/fix.md"
+            ".github/ISSUE_TEMPLATE/feature.md"
             ".github/pull_request_template.md"
             ".github/labeler.yml"
             ".github/release-drafter.yml"
@@ -195,7 +195,7 @@ jobs:
         working-directory: /tmp/test-project
         run: |
           md_files=(
-            ".github/ISSUE_TEMPLATE/bug_report.md"
+            ".github/ISSUE_TEMPLATE/fix.md"
             ".github/pull_request_template.md"
             "CONTRIBUTING.md"
           )


### PR DESCRIPTION
## Related Issue

Closes #64

## Context

PR #59 renamed issue templates from `bug_report.md`/`feature_request.md` to `fix.md`/`feature.md` to align with the type convention. However, the `test-setup-script.yml` workflow was not updated to reflect these new names, causing CI failures.

## Changes

- Updated `test-setup-script.yml` to check for `fix.md` instead of `bug_report.md`
- Updated `test-setup-script.yml` to check for `feature.md` instead of `feature_request.md`
- Updated manifest expected files list to use new template names
- Updated markdown header validation to use `fix.md` instead of `bug_report.md`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Steps

1. Run the workflow locally using `act`:
   ```bash
   act push -W .github/workflows/test-setup-script.yml --container-architecture linux/amd64
   ```
2. Verify all steps pass, especially "Verify issue templates were copied"

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes locally using `act`

🤖 Generated with [Claude Code](https://claude.com/claude-code)