### PR TITLE
ci: remove paths filter from test workflow for reliable status checks

### DIFF
--- a/.github/workflows/test-setup-script.yml
+++ b/.github/workflows/test-setup-script.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - 'setup.sh'
-      - '.github/**'
-      - 'CONTRIBUTING.md'
 
 jobs:
   test-setup:


### PR DESCRIPTION
## Related Issue

Closes #66

## Context

The `Test setup.sh execution` workflow currently only runs when specific files (`setup.sh`, `.github/**`, `CONTRIBUTING.md`) are modified. This makes it unsuitable as a required status check because PRs not touching those files won't have the check at all.

Removing the paths filter allows this workflow to run on all PRs, making it reliable as a required status check.

## Changes

- Removed `paths` filter from `pull_request` trigger in `test-setup-script.yml`

## Type of Change

- [x] CI configuration change

## Test Steps

1. Create a test PR that doesn't modify `setup.sh`, `.github/**`, or `CONTRIBUTING.md`
2. Verify the `Test setup.sh execution` workflow runs

## Post-Merge Steps

After merging this PR, configure branch protection via GitHub Settings:

1. Go to **Settings → Branches → Add branch protection rule**
2. Branch name pattern: `main`
3. Enable **Require status checks to pass before merging**
4. Add required checks:
   - `Validate PR title`
   - `Test setup.sh execution`
5. (Optional) Enable **Require branches to be up to date before merging**
6. Save changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)