### PR TITLE
documentation: update README manifest example with renamed templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The manifest file (`.coding-guideline-manifest.txt`) tracks all copied files:
 version: abc1234567890...
 .github/workflows/labeler.yml
 .github/workflows/release-drafter.yml
-.github/ISSUE_TEMPLATE/bug_report.md
+.github/ISSUE_TEMPLATE/fix.md
+.github/ISSUE_TEMPLATE/feature.md
 .github/pull_request_template.md
 CONTRIBUTING.md
 ```


### PR DESCRIPTION
## Related Issue

Closes #72

## Context

PR #59 renamed issue templates from `bug_report.md`/`feature_request.md` to `fix.md`/`feature.md` to align with the type convention. PR #65 updated the test workflow to use the new names, but the README.md manifest example was not updated and still showed the old filename.

## Changes

- Update README.md manifest example to show `fix.md` and `feature.md` instead of `bug_report.md`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Test Steps

1. Review the README.md changes
2. Verify the manifest example matches the actual template files in `.github/ISSUE_TEMPLATE/`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)