### PR TITLE
fix: allow check-links workflow to pass with no links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           args: --verbose --no-progress '**/*.md'
           fail: true
+          failIfEmpty: false


### PR DESCRIPTION
## Related Issue

Closes #76

## Context

The `check-links.yml` workflow fails in repositories that have no hyperlinks in their markdown files. This blocks PRs in new projects or repos with minimal documentation (like embedded/hardware projects).

## Changes

- Add `failIfEmpty: false` to the lychee-action configuration

This allows the workflow to pass gracefully when no links exist, while still failing on actual broken links.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Configuration/maintenance
- [ ] Documentation
- [ ] Breaking change

## Test Steps

1. Apply this change to a repo with no markdown links
2. Create a PR
3. Verify "Check documentation links" job passes

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have performed a self-review
- [x] Changes are limited to what is described

🤖 Generated with [Claude Code](https://claude.ai/code)