### PR TITLE
feature: expand ruff.toml with additional rule sets for automated enforcement

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -24,11 +24,28 @@ select = [
     "TCH",  # flake8-type-checking (Move imports to type-checking blocks)
     "PL",   # Pylint (Complexity & standard rules)
     "RUF",  # Ruff-specific rules (Unused imports, etc.)
+    "D",    # pydocstyle (Docstring enforcement - PYTHON.md Section 5)
+    "ARG",  # flake8-unused-arguments
+    "ERA",  # eradicate (No commented-out code)
+    "FBT",  # flake8-boolean-trap (Clearer function signatures)
+    "PIE",  # flake8-pie (Misc. lints for cleaner code)
+    "S",    # flake8-bandit (Security checks)
+    "PT",   # flake8-pytest-style (Test consistency)
 ]
 
 ignore = [
     "PLR2004", # Magic values comparison (sometimes necessary in math SDKs)
 ]
+
+[lint.per-file-ignores]
+# Private modules don't need docstrings per PYTHON.md
+"_*.py" = ["D"]
+# Test files: allow assert (S101), skip docstrings
+"tests/*" = ["D", "S101"]
+
+[lint.pydocstyle]
+# Match PYTHON.md Section 5: Ruff lacks native Sphinx, PEP257 is closest
+convention = "pep257"
 
 [lint.pylint]
 # Approx proxies for strict line limits:


### PR DESCRIPTION
## Summary

- Add 7 new Ruff rule sets (`D`, `ARG`, `ERA`, `FBT`, `PIE`, `S`, `PT`) to automate enforcement of PYTHON.md guidelines
- Configure `per-file-ignores` for test files and private modules
- Add `[lint.pydocstyle]` section with PEP257 convention

## Related Issue

Closes #80

## Context

The current `ruff.toml` uses proxy metrics (e.g., `max-statements`) to approximate line limits, but several PYTHON.md requirements had no automated enforcement. This change adds rule sets that directly check for violations, shifting enforcement from manual review to CI.

## Changes

| Rule Set | Purpose |
|----------|---------|
| `D` | Docstring enforcement (PYTHON.md Section 5) |
| `ARG` | Unused function arguments |
| `ERA` | Commented-out code detection |
| `FBT` | Boolean trap anti-patterns |
| `PIE` | Miscellaneous lints |
| `S` | Security checks (bandit) |
| `PT` | Pytest style consistency |

**Per-file ignores:**
- `_*.py`: Skip docstring checks (private modules)
- `tests/*`: Skip docstrings + allow `assert` (S101)

## Type of Change

- [x] New feature (non-breaking)

## Test Steps

1. Run `ruff check` on a Python file missing a docstring → should report `D` violation
2. Run `ruff check` on a test file with `assert` → should pass (S101 ignored)
3. Verify existing codebase passes or violations are expected

## Checklist

- [x] Changes follow project conventions
- [x] Self-review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)