### PR TITLE
feature: copy CLAUDE.md template during setup.sh install

### DIFF
--- a/.github/workflows/test-setup-script.yml
+++ b/.github/workflows/test-setup-script.yml
@@ -282,6 +282,45 @@ jobs:
 
           echo "✓ Reinstall after remove works correctly"
 
+      # CLAUDE.md template tests
+      - name: Verify CLAUDE.md was created on install
+        working-directory: /tmp/test-project
+        run: |
+          if [ ! -f "CLAUDE.md" ]; then
+            echo "ERROR: CLAUDE.md was not created during install"
+            exit 1
+          fi
+          echo "✓ CLAUDE.md created on install"
+
+      - name: Verify CLAUDE.md is not tracked in manifest
+        working-directory: /tmp/test-project
+        run: |
+          if grep -q "^CLAUDE.md$" .coding-guideline-manifest.txt; then
+            echo "ERROR: CLAUDE.md should not be tracked in manifest"
+            exit 1
+          fi
+          echo "✓ CLAUDE.md is not tracked in manifest"
+
+      - name: Verify CLAUDE.md has no managed-by header
+        working-directory: /tmp/test-project
+        run: |
+          if head -n 1 CLAUDE.md | grep -q "Managed by CodingGuideline"; then
+            echo "ERROR: CLAUDE.md should not have a managed-by header"
+            exit 1
+          fi
+          echo "✓ CLAUDE.md has no managed-by header"
+
+      - name: Test CLAUDE.md is not overwritten on reinstall
+        working-directory: /tmp/test-project
+        run: |
+          echo "# Custom project content" > CLAUDE.md
+          ./setup.sh install
+          if ! grep -q "# Custom project content" CLAUDE.md; then
+            echo "ERROR: CLAUDE.md was overwritten during reinstall"
+            exit 1
+          fi
+          echo "✓ CLAUDE.md preserved on reinstall"
+
       - name: Display test project structure
         working-directory: /tmp/test-project
         run: |

--- a/setup.sh
+++ b/setup.sh
@@ -71,6 +71,25 @@ copy_with_tracking() {
     add_to_manifest "$dest"
 }
 
+# Copy CLAUDE.md template if it doesn't already exist (not tracked in manifest)
+copy_claude_md() {
+    local src="$1"
+
+    if [ -f "CLAUDE.md" ]; then
+        echo -e "${YELLOW}CLAUDE.md already exists, skipping${NC}"
+        return
+    fi
+
+    if [ ! -f "$src" ]; then
+        echo -e "${YELLOW}CLAUDE.md template not found, skipping${NC}"
+        return
+    fi
+
+    echo -e "${YELLOW}Copying CLAUDE.md template...${NC}"
+    cp "$src" "CLAUDE.md"
+    echo -e "${GREEN}✓ CLAUDE.md created (customize it for your project)${NC}"
+}
+
 # Install/setup command
 install_files() {
     echo -e "${GREEN}Coding Guideline Setup${NC}"
@@ -157,15 +176,18 @@ install_files() {
         echo -e "${GREEN}✓ Release drafter configuration copied${NC}"
     fi
 
+    # Copy CLAUDE.md template (not tracked in manifest - users customize this file)
+    copy_claude_md "$SUBMODULE_PATH/templates/CLAUDE.md"
+
     echo ""
     echo -e "${GREEN}================================${NC}"
     echo -e "${GREEN}Setup complete!${NC}"
     echo ""
     echo "Next steps:"
     echo "1. Review the copied files in .github/"
-    echo "2. Customize them for your project if needed"
+    echo "2. Customize CLAUDE.md for your project"
     echo "3. Commit the changes:"
-    echo "   git add .github/ $SUBMODULE_PATH $MANIFEST_FILE"
+    echo "   git add .github/ CLAUDE.md $SUBMODULE_PATH $MANIFEST_FILE"
     echo "   git commit -m 'chore: add coding guidelines'"
     echo ""
     echo "To update guidelines: ./setup.sh update"


### PR DESCRIPTION
## Related Issue

Closes #82

## Context

The `setup.sh` script copies workflows, issue templates, PR template, labeler config, and release drafter config automatically, but `CLAUDE.md` still required a separate manual copy step (`cp .coding-guideline/templates/CLAUDE.md ./CLAUDE.md`). This is inconsistent and easy to forget during initial setup.

## Changes

- Add `copy_claude_md` function to `setup.sh` that copies the template on fresh install
- Skip copying if `CLAUDE.md` already exists (preserves user customizations)
- CLAUDE.md is **not** tracked in the manifest and has **no** managed-by header, since users are expected to customize it
- Update "Next steps" output to mention `CLAUDE.md`
- Add CI tests for the new behavior

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Steps

1. Run `./setup.sh` in a fresh git repo — verify `CLAUDE.md` is created
2. Modify `CLAUDE.md`, run `./setup.sh` again — verify custom content is preserved
3. Run `./setup.sh update` — verify `CLAUDE.md` is not overwritten
4. Check `.coding-guideline-manifest.txt` — verify `CLAUDE.md` is not listed

## Checklist

- [x] My code follows the project's coding guidelines
- [x] I have performed a self-review of my own code
- [x] New and existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)