### PR TITLE
documentation: remove redundant Claude configuration section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,22 +105,6 @@ git clone --recurse-submodules <your-project-url>
 git submodule update --init --recursive
 ```
 
-### Claude Configuration for Derivative Repositories
-
-If you use Claude Code in your derivative repository, copy the template file to your project root:
-
-```bash
-cp .coding-guideline/templates/CLAUDE.md ./CLAUDE.md
-```
-
-Then customize it for your project:
-1. Uncomment the language-specific guidelines that apply (e.g., Python)
-2. Add any project-specific guidelines in the designated section
-
-See [`templates/CLAUDE.md`](templates/CLAUDE.md) for the full template.
-
-This instructs Claude to check for the submodule and initialize it if needed, and directs it to the appropriate guidelines for development practices.
-
 ## License
 
 This project is licensed under CC0 1.0 Universal - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Related Issue

Closes #84

## Context

The "Claude Configuration for Derivative Repositories" section in `README.md` documented a manual `cp` command for copying the CLAUDE.md template. Since PR #83 merged, `setup.sh` handles this automatically during installation and already prompts users to customize the file via the "Next steps" output. The section is now misleading — it implies a manual step that no longer exists.

## Changes

- Remove the "Claude Configuration for Derivative Repositories" subsection from `README.md`

## Type of Change

- [ ] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking change (existing functionality will not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Test Steps

1. Read `README.md` and verify the "Claude Configuration for Derivative Repositories" section is gone
2. Run `setup.sh` in a test repo and confirm CLAUDE.md is still copied automatically

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or my feature works
- [x] I have updated documentation as needed