### PR TITLE
fix: add synchronize and reopened triggers to labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 jobs:
   labeler:
     permissions:


### PR DESCRIPTION
## Related Issue

Closes #88

## Context

The labeler workflow only triggered on the \`opened\` event. When additional commits were pushed to a PR after it was opened, the labeler never re-ran on the new HEAD. In repositories that require the labeler as a status check (e.g. IshitaTakeshi/Sensing), this left the check permanently pending ("Expected — Waiting for status to be reported"), blocking the PR from merging.

Concrete case: IshitaTakeshi/Sensing PR #34 is currently blocked because two commits were pushed after the PR was opened, and the labeler ran only on the first commit.

## Changes

- `.github/workflows/labeler.yml`: add `synchronize` and `reopened` to `pull_request_target` trigger types

## Type of Change

- [x] Bug fix

## Test Steps

1. Open a PR from a branch matching a labeler rule (e.g. `fix/*`)
2. Push an additional commit to the PR branch
3. Verify the labeler check runs and passes on the new commit

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation as needed

## Review Focus (optional)

Confirm that adding `synchronize` and `reopened` does not cause unintended side effects (e.g. label flickering on force-push). Since `sync-labels: false`, existing labels are not removed, so this is safe.