### PR TITLE
fix: use grep to safely strip version line from manifest on update

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -244,7 +244,7 @@ update_files() {
     # Update version in manifest
     {
         echo "version: ${VERSION}"
-        tail -n +2 "$MANIFEST_FILE"
+        grep -v "^version: " "$MANIFEST_FILE" || true
     } > "${MANIFEST_FILE}.tmp"
     mv "${MANIFEST_FILE}.tmp" "$MANIFEST_FILE"
 


### PR DESCRIPTION
## Summary

- Replaces `tail -n +2` with `grep -v "^version: "` when rewriting the manifest version in `update_files()`
- `tail -n +2` skips by line number — if the manifest is corrupted and the `version:` line is absent, it silently drops the first tracked file path instead
- `grep -v "^version: "` filters by content, preserving all file paths regardless of manifest structure
- `|| true` prevents `set -e` from killing the script when grep finds no matches (e.g. version-only manifest)

Closes #92