### PR TITLE
test: assert file count is preserved when recovering corrupted manifest

### DIFF
--- a/.github/workflows/test-setup-script.yml
+++ b/.github/workflows/test-setup-script.yml
@@ -451,6 +451,9 @@ jobs:
           cp /tmp/test-project/setup.sh .
           ./setup.sh
 
+          # Count files before corruption
+          expected_count=$(wc -l < .coding-guideline-manifest.txt)
+
           # Corrupt the manifest (remove version line)
           tail -n +2 .coding-guideline-manifest.txt > .coding-guideline-manifest.txt.tmp
           mv .coding-guideline-manifest.txt.tmp .coding-guideline-manifest.txt
@@ -458,13 +461,20 @@ jobs:
           # Update should still work - it will add version line
           ./setup.sh update
 
+          # Verify file count wasn't affected by the update dropping a path
+          actual_count=$(wc -l < .coding-guideline-manifest.txt)
+          if [ "$expected_count" -ne "$actual_count" ]; then
+            echo "ERROR: File count changed from $expected_count to $actual_count after recovering corrupted manifest"
+            exit 1
+          fi
+
           # Verify version line was added back
           if ! grep -q "^version: " .coding-guideline-manifest.txt; then
             echo "ERROR: Version line should be restored"
             exit 1
           fi
 
-          echo "✓ Update handles corrupted manifest"
+          echo "✓ Update handles corrupted manifest without data loss"
           rm -rf /tmp/test-corrupt-manifest
 
       - name: Test update without manifest file

--- a/setup.sh
+++ b/setup.sh
@@ -244,7 +244,7 @@ update_files() {
     # Update version in manifest
     {
         echo "version: ${VERSION}"
-        tail -n +2 "$MANIFEST_FILE"
+        grep -v "^version: " "$MANIFEST_FILE" || true
     } > "${MANIFEST_FILE}.tmp"
     mv "${MANIFEST_FILE}.tmp" "$MANIFEST_FILE"
 


### PR DESCRIPTION
## Summary

- Adds `wc -l` snapshots before and after update in the corrupted-manifest test
- The previous test only verified the version line was restored — it would have passed even if a file path was silently dropped
- This closes the CI blind spot that let the bug in #94 go undetected

> **Depends on #94** (rebased on top of that branch)

Closes #93