### PR TITLE
feature: add JavaScript/TypeScript coding standards

### DIFF
--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -1,0 +1,177 @@
+# Coding Standards & Guidelines
+
+> **Philosophy:** "Pure, Atomic, Trivial."
+> Every component must be small enough to be understood at a glance. Complexity is managed through composition, not indentation.
+
+## 1. Structure & Size Limits (Strict)
+
+We adhere to **Object Calisthenics** rules to force modularity.
+
+| Scope | Max Size (excluding comments/JSDoc) |
+| :--- | :--- |
+| **File** | **100 lines** |
+| **Class / Module** | **50 lines** |
+| **Function** | **15 lines** |
+
+* **File Sizing:** If a file exceeds 100 lines, it must be split. A file should contain only one class or a small set of tightly coupled functions.
+* **Function Sizing:** The 15-line limit is absolute.
+    * *Exceptions:* None. Even `try...catch` blocks must be concise. If error handling is complex, delegate the logic inside the `try` block to a separate private function.
+    * *When a function is too long:* Extract a sub-function. Never bundle parameters into a single "options" object just to shrink the signature. See [Section 7](#7-complexity-reduction-no-artificial-grouping).
+
+## 2. Control Flow: The "No Else" Rule
+
+**The `else` keyword is forbidden.** Use Guard Clauses (Early Returns) instead.
+
+**Incorrect:**
+```javascript
+function calculateStatus(value) {
+    if (value > 10) {
+        return "High";
+    } else {
+        return "Low";
+    }
+}
+
+```
+
+**Correct:**
+
+```javascript
+function calculateStatus(value) {
+    if (value > 10) {
+        return "High";
+    }
+    return "Low";
+}
+
+```
+
+## 3. Naming Conventions
+
+* **Style:** `camelCase` for functions, variables, and instances. `PascalCase` for classes, interfaces, and types. `UPPER_SNAKE_CASE` for global constants.
+* **Zero Tolerance for Abbreviations:** Names must be fully descriptive. Ambiguity is technical debt.
+
+| Forbidden | Required Replacement |
+| --- | --- |
+| `idx`, `i` | `index`, `sequenceIndex` |
+| `ctx` | `context` |
+| `cb` | `callback`, `onComplete` |
+| `val` | `value` |
+| `req` / `res` | `request` / `response` |
+| `err` | `error` |
+
+## 4. Type Safety
+
+* **Strict Mode:** All code must run strictly (`"use strict";` or natively via ES Modules) and pass TypeScript strict checks (or strict JSDoc via `tsc --noEmit`).
+* **No `any`:** The use of `any` (or implicit any) is forbidden. If a type is truly dynamic, use `unknown` and narrow it with type guards, or use Generics (`<T>`).
+* **Signatures:** Every function (public or private) must have explicit parameter and return types defined via TypeScript or JSDoc.
+
+## 5. Documentation
+
+* **Format:** JSDoc.
+* **Requirement:** Mandatory JSDoc blocks for all **Public** (exported) Modules, Classes, and Functions.
+* **Content:** Do not just repeat the type information if using TypeScript. Focus on the *purpose*, *behavior*, and *side effects*.
+
+```javascript
+/**
+ * Establishes the initial connection pool to the database.
+ * @param {string} connectionString - The fully qualified database URI.
+ * @returns {Promise<void>}
+ * @throws {ConnectionError} If the remote host is unreachable.
+ */
+async function connectToDatabase(connectionString) {
+    // ...
+}
+
+```
+
+## 6. Imports
+
+* **Sorting:** Automated via ESLint (`eslint-plugin-import` or `simple-import-sort`).
+* **Unused Imports:** Strictly forbidden. The build will fail if detected.
+* **Paths:** Prefer absolute alias paths (e.g., `@/components/`) over deep relative paths (`../../../components/`).
+
+## 7. Complexity Reduction: No Artificial Grouping
+
+When a function exceeds size or argument limits, **decompose its logic** into smaller functions — do not bundle its parameters into an "options" object or wrapper type just to bypass the rules.
+
+### The Anti-Pattern
+
+Creating a TypeScript `interface`, `type`, or JSDoc `@typedef` purely to fit a long signature into one argument does not reduce complexity. It displaces it. The same operations still happen on the same data; only the surface area changed.
+
+```javascript
+// Wrong: SubplotConfig exists only to hide three arguments.
+// The function is no simpler; callers now bear the construction cost.
+
+/**
+ * @typedef {Object} SubplotConfig
+ * @property {Function} accessor
+ * @property {string} ylabel
+ * @property {string} title
+ */
+
+function _configureSubplot(axis, config, ...) {
+    // ...
+}
+
+```
+
+```javascript
+// Correct: extract a sub-function with a single, nameable responsibility.
+// _plotSeries can be understood, tested, and reused independently.
+function _plotSeries(axis, label, accessor, result) {
+    // ...
+}
+
+function _configureSubplot(axis, accessor, ylabel, title, ...) {
+    for (const [label, result] of Object.entries(results)) {
+        _plotSeries(axis, label, accessor, result);
+    }
+    _decorateAxis(axis, ylabel, title);
+}
+
+```
+
+### Litmus Test for a Legitimate Type / Object
+
+An options object or data structure is legitimate only if **all three** conditions hold:
+
+1. **Domain-named:** Its name comes from the problem domain, not from code structure. Red flags: `Config`, `Options`, `Params`, `Data`, `Info`.
+2. **Restriction-independent:** It would exist even with no function size limit.
+3. **Single entity:** Its properties describe one holistic thing, not a collection of unrelated arguments that happen to go to the same function.
+
+| ✅ Legitimate | ❌ Artificial |
+| --- | --- |
+| `SuspensionParameters` — a named concept in vehicle dynamics | `PlotStyle` — two generic args bundled to shrink a signature |
+| `SimulationResult` — natural return type shared across module boundaries | `SubplotConfig` — three unrelated fields with only one consumer |
+
+### When a Function Is Still Too Long
+
+Ask: **"What distinct step can I name?"** Extract that named step into a private function. The size limit exists to force you to name every concept — not to encourage hiding concepts inside wrapper objects.
+
+## 8. Tooling
+
+This repository provides configuration files for automated enforcement.
+
+### ESLint (Linter & Formatter)
+
+Derivative repositories can extend the shared ESLint configuration:
+
+```js
+// eslint.config.js
+import baseConfig from "./.coding-guideline/eslint.config.js";
+export default [...baseConfig];
+```
+
+### TypeScript (Type Checker)
+
+TypeScript supports configuration inheritance via `extends`. Use the shared base config in `tsconfig.json`:
+
+```json
+{
+  "extends": "./.coding-guideline/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  }
+}
+```

--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -17,6 +17,7 @@ We adhere to **Object Calisthenics** rules to force modularity.
 * **Function Sizing:** The 15-line limit is absolute.
     * *Exceptions:* None. Even `try...catch` blocks must be concise. If error handling is complex, delegate the logic inside the `try` block to a separate private function.
     * *When a function is too long:* Extract a sub-function. Never bundle parameters into a single "options" object just to shrink the signature. See [Section 7](#7-complexity-reduction-no-artificial-grouping).
+* **Parameter Limit:** Functions may accept at most **3 parameters**. When a function needs more, decompose its logic — do not bundle parameters into an "options" object. See [Section 7](#7-complexity-reduction-no-artificial-grouping).
 
 ## 2. Control Flow: The "No Else" Rule
 
@@ -110,7 +111,7 @@ Creating a TypeScript `interface`, `type`, or JSDoc `@typedef` purely to fit a l
  * @property {string} title
  */
 
-function _configureSubplot(axis, config, ...) {
+function _configureSubplot(axis, config) {
     // ...
 }
 
@@ -123,7 +124,7 @@ function _plotSeries(axis, label, accessor, result) {
     // ...
 }
 
-function _configureSubplot(axis, accessor, ylabel, title, ...) {
+function _configureSubplot(axis, accessor, ylabel, title) {
     for (const [label, result] of Object.entries(results)) {
         _plotSeries(axis, label, accessor, result);
     }
@@ -155,7 +156,13 @@ This repository provides configuration files for automated enforcement.
 
 ### ESLint (Linter & Formatter)
 
-Derivative repositories can extend the shared ESLint configuration:
+The shared config supports both JavaScript and TypeScript. Install the required peer dependency first:
+
+```sh
+npm install --save-dev typescript-eslint
+```
+
+Then extend it in your project:
 
 ```js
 // eslint.config.js

--- a/JAVASCRIPT.md
+++ b/JAVASCRIPT.md
@@ -63,7 +63,7 @@ function calculateStatus(value) {
 
 ## 4. Type Safety
 
-* **Strict Mode:** All code must run strictly (`"use strict";` or natively via ES Modules) and pass TypeScript strict checks (or strict JSDoc via `tsc --noEmit`).
+* **Strict Mode:** All code must run strictly (`"use strict";` or natively via ES Modules) and pass TypeScript strict checks (or strict JSDoc via `tsc --noEmit`). JavaScript-only projects using JSDoc must add `"allowJs": true` and `"checkJs": true` to their `tsconfig.json` to enable type checking.
 * **No `any`:** The use of `any` (or implicit any) is forbidden. If a type is truly dynamic, use `unknown` and narrow it with type guards, or use Generics (`<T>`).
 * **Signatures:** Every function (public or private) must have explicit parameter and return types defined via TypeScript or JSDoc.
 
@@ -88,7 +88,7 @@ async function connectToDatabase(connectionString) {
 
 ## 6. Imports
 
-* **Sorting:** Automated via ESLint (`eslint-plugin-import` or `simple-import-sort`).
+* **Sorting:** Can be automated via ESLint (e.g., `eslint-plugin-import` or `simple-import-sort`), but requires a plugin configured in the consuming project — not included in the shared `eslint.config.js`.
 * **Unused Imports:** Strictly forbidden. The build will fail if detected.
 * **Paths:** Prefer absolute alias paths (e.g., `@/components/`) over deep relative paths (`../../../components/`).
 
@@ -106,9 +106,9 @@ Creating a TypeScript `interface`, `type`, or JSDoc `@typedef` purely to fit a l
 
 /**
  * @typedef {Object} SubplotConfig
- * @property {Function} accessor
  * @property {string} ylabel
  * @property {string} title
+ * @property {string} color
  */
 
 function _configureSubplot(axis, config) {
@@ -120,13 +120,13 @@ function _configureSubplot(axis, config) {
 ```javascript
 // Correct: extract a sub-function with a single, nameable responsibility.
 // _plotSeries can be understood, tested, and reused independently.
-function _plotSeries(axis, label, accessor, result) {
+function _plotSeries(axis, label, result) {
     // ...
 }
 
-function _configureSubplot(axis, accessor, ylabel, title) {
+function _configureSubplot(axis, ylabel, title) {
     for (const [label, result] of Object.entries(results)) {
-        _plotSeries(axis, label, accessor, result);
+        _plotSeries(axis, label, result);
     }
     _decorateAxis(axis, ylabel, title);
 }
@@ -182,3 +182,10 @@ TypeScript supports configuration inheritance via `extends`. Use the shared base
   }
 }
 ```
+
+> **Minimum version:** The base config uses `"moduleResolution": "bundler"`, which requires **TypeScript ≥ 5.0**.
+
+> **Browser projects:** The base `lib` targets ES2020 only. Add `"DOM"` and `"DOM.Iterable"` in your project's `tsconfig.json`:
+> ```json
+> { "compilerOptions": { "lib": ["ES2020", "DOM", "DOM.Iterable"] } }
+> ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,26 +4,63 @@
 //   // eslint.config.js
 //   import baseConfig from "./.coding-guideline/eslint.config.js";
 //   export default [...baseConfig];
+//
+// Peer dependency required:
+//   npm install --save-dev typescript-eslint
+
+import tseslint from "typescript-eslint";
+
+/** @type {Record<string, unknown>} */
+const sharedRules = {
+  // Section 1: Structure & Size Limits
+  "max-lines": ["error", { "max": 100, "skipBlankLines": true, "skipComments": true }],
+  "max-lines-per-function": ["error", { "max": 15, "skipBlankLines": true, "skipComments": true }],
+  "max-params": ["error", 3],
+
+  // Section 2: Control Flow — No Else (bans all else, including else-if)
+  "no-restricted-syntax": [
+    "error",
+    {
+      selector: "IfStatement[alternate]",
+      message: "The else keyword is forbidden. Use guard clauses (early returns) instead.",
+    },
+  ],
+
+  // Section 6: Imports
+  "no-duplicate-imports": "error",
+
+  // Section 7: Complexity Reduction
+  "complexity": ["error", 4],
+  "max-depth": ["error", 2],
+};
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
+  // JavaScript
   {
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
     rules: {
-      // Section 1: Structure & Size Limits
-      "max-lines": ["error", { "max": 100, "skipBlankLines": true, "skipComments": true }],
-      "max-lines-per-function": ["error", { "max": 15, "skipBlankLines": true, "skipComments": true }],
-      "max-params": ["error", 3],
-
-      // Section 2: Control Flow — No Else
-      "no-else-return": "error",
-
-      // Section 6: Imports
+      ...sharedRules,
       "no-unused-vars": "error",
-      "no-duplicate-imports": "error",
+    },
+  },
 
-      // Section 7: Complexity Reduction
-      "complexity": ["error", 4],
-      "max-depth": ["error", 2],
+  // TypeScript
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    languageOptions: {
+      parser: tseslint.parser,
+    },
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
+    },
+    rules: {
+      ...sharedRules,
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "error",
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,7 +34,7 @@ const sharedRules = {
   "max-depth": ["error", 2],
 };
 
-/** @type {import("eslint").Linter.Config[]} */
+/** @type {import("eslint").Linter.FlatConfig[]} */
 export default [
   // JavaScript
   {
@@ -50,7 +50,7 @@ export default [
 
   // TypeScript
   {
-    files: ["**/*.ts", "**/*.tsx"],
+    files: ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts", "**/*.mtsx", "**/*.ctsx"],
     languageOptions: {
       parser: tseslint.parser,
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,29 @@
+// Strict JavaScript/TypeScript ESLint Configuration
+// Derivative repositories can extend this:
+//
+//   // eslint.config.js
+//   import baseConfig from "./.coding-guideline/eslint.config.js";
+//   export default [...baseConfig];
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  {
+    rules: {
+      // Section 1: Structure & Size Limits
+      "max-lines": ["error", { "max": 100, "skipBlankLines": true, "skipComments": true }],
+      "max-lines-per-function": ["error", { "max": 15, "skipBlankLines": true, "skipComments": true }],
+      "max-params": ["error", 3],
+
+      // Section 2: Control Flow — No Else
+      "no-else-return": "error",
+
+      // Section 6: Imports
+      "no-unused-vars": "error",
+      "no-duplicate-imports": "error",
+
+      // Section 7: Complexity Reduction
+      "complexity": ["error", 4],
+      "max-depth": ["error", 2],
+    },
+  },
+];

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020"],
+    "moduleResolution": "bundler",
     "strict": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
## Related Issue

Closes #96

## Context

`PYTHON.md` is backed by `ruff.toml` and `mypy.toml` — shared config files that derivative repos extend in one line. JavaScript projects using this submodule had no equivalent document or tooling, leaving JS/TS codebases without guidance or automated enforcement.

## Changes

- Add `JAVASCRIPT.md`: ports all 8 sections from `PYTHON.md`, adapting syntax examples, naming conventions (`camelCase`, JSDoc, `unknown` over `any`), and tooling references to JavaScript/TypeScript
- Add `eslint.config.js`: shared flat ESLint config encoding the rules from Sections 1, 2, 6, and 7; derivative repos extend it with a single import
- Add `tsconfig.base.json`: shared TypeScript strict compiler options from Section 4; derivative repos extend it via `"extends"`

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation update

## Test Steps

1. Clone the repo and navigate to the root.
2. Review `JAVASCRIPT.md` and confirm all 8 sections are present and consistent with `PYTHON.md`'s structure.
3. In a scratch JS project with the submodule, create `eslint.config.js`:
   ```js
   import baseConfig from "./.coding-guideline/eslint.config.js";
   export default [...baseConfig];
   ```
   Run `npx eslint .` and confirm the rules from Sections 1, 2, 6, 7 are enforced.
4. Create `tsconfig.json`:
   ```json
   { "extends": "./.coding-guideline/tsconfig.base.json" }
   ```
   Run `tsc --noEmit` and confirm strict checks are active.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have tested this change locally
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation as needed

## Review Focus (optional)

- `eslint.config.js`: verify the rule set faithfully encodes the philosophy without missing sections
- `JAVASCRIPT.md` Section 8: confirm the extension snippets match what a developer would actually type