### PR TITLE
fix(ruff): raise max-statements to 15 to match the 15-line guideline

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -48,9 +48,9 @@ ignore = [
 convention = "pep257"
 
 [lint.pylint]
-# Approx proxies for strict line limits:
-# 15 lines ~ 7-10 statements
-max-statements = 10
+# Approx proxies for strict line limits (excluding comments/docstrings):
+# 15 lines ~ 10-15 statements depending on nesting and control flow
+max-statements = 15
 # 50 lines class ~ 7 public methods + 3-4 attributes
 max-public-methods = 7
 # No branches allowed basically means very low complexity


### PR DESCRIPTION
## Summary

- `max-statements` was set to `10`, but a 15-line function (the actual limit, excluding comments/docstrings) can have 10–15 statements depending on nesting and control flow
- This caused false positives on code that was well within the real guideline, leading to unnecessary workarounds
- Raises the proxy to `15` and tightens the comment to clarify both the range and the "excluding comments/docstrings" basis

## Test plan

- [ ] Verify that a function with 15 code lines (excluding comments/docstrings) no longer triggers PLR0915
- [ ] Verify that a function genuinely exceeding 15 code lines still triggers PLR0915

🤖 Generated with [Claude Code](https://claude.com/claude-code)