### PR TITLE
documentation: add milestone branch workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,5 @@
+milestone:
+  - head-branch: ['^milestone/']
 feature:
   - head-branch: ['^feature/']
 fix:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,9 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
+  - title: '🎯 Milestone Releases'
+    labels:
+      - 'milestone'
   - title: '🚀 Features'
     labels:
       - 'feature'

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -66,13 +66,13 @@ def determine_label(commits):
     for commit in commits:
         subject = commit["commit"]["message"].split("\n")[0]
         if BREAKING_RE.match(subject):
-            return "major"
+            return Label.MAJOR
         m = TYPE_RE.match(subject)
         if not m:
             continue
         type_ = m.group(1)
-        if type_ == "feature" and priority > 1:
-            label, priority = "feature", 1
+        if type_ == Label.FEATURE and priority > 1:
+            label, priority = Label.FEATURE, 1
         elif type_ in PATCH_TYPES and priority > 2:
             label, priority = type_, 2
     return label

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -5,22 +5,10 @@ the highest-impact version label: major > feature > fix/performance/revert.
 If no versioned commits are found, no label is assigned (no version bump).
 """
 
-import os
+import argparse
 import re
-import sys
 
 import requests
-
-TOKEN = os.environ["GITHUB_TOKEN"]
-REPO = os.environ["GITHUB_REPOSITORY"]
-PR_NUMBER = int(os.environ["PR_NUMBER"])
-
-HEADERS = {
-    "Authorization": f"Bearer {TOKEN}",
-    "Accept": "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-}
-BASE_URL = f"https://api.github.com/repos/{REPO}"
 
 BREAKING_RE = re.compile(r"^[a-z]+(\([^)]+\))?!:")
 TYPE_RE = re.compile(r"^([a-z]+)(?:\([^)]+\))?!?:")
@@ -28,13 +16,29 @@ PATCH_TYPES = {"fix", "performance", "revert"}
 VERSION_LABELS = {"major", "feature", "fix", "performance", "revert"}
 
 
-def get_commits():
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--token", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr-number", type=int, required=True)
+    return parser.parse_args()
+
+
+def make_headers(token):
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def get_commits(repo, pr_number, headers):
     commits = []
     page = 1
     while True:
         resp = requests.get(
-            f"{BASE_URL}/pulls/{PR_NUMBER}/commits",
-            headers=HEADERS,
+            f"https://api.github.com/repos/{repo}/pulls/{pr_number}/commits",
+            headers=headers,
             params={"per_page": 100, "page": page},
         )
         resp.raise_for_status()
@@ -54,52 +58,60 @@ def determine_label(commits):
         if BREAKING_RE.match(subject):
             return "major"
         m = TYPE_RE.match(subject)
-        if m:
-            type_ = m.group(1)
-            if type_ == "feature" and priority > 1:
-                label, priority = "feature", 1
-            elif type_ in PATCH_TYPES and priority > 2:
-                label, priority = type_, 2
+        if not m:
+            continue
+        type_ = m.group(1)
+        if type_ == "feature" and priority > 1:
+            label, priority = "feature", 1
+        elif type_ in PATCH_TYPES and priority > 2:
+            label, priority = type_, 2
     return label
 
 
-def get_current_labels():
-    resp = requests.get(f"{BASE_URL}/issues/{PR_NUMBER}/labels", headers=HEADERS)
+def get_current_labels(repo, pr_number, headers):
+    resp = requests.get(
+        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
+        headers=headers,
+    )
     resp.raise_for_status()
     return [entry["name"] for entry in resp.json()]
 
 
-def remove_label(name):
+def remove_label(repo, pr_number, name, headers):
     resp = requests.delete(
-        f"{BASE_URL}/issues/{PR_NUMBER}/labels/{name}", headers=HEADERS
+        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels/{name}",
+        headers=headers,
     )
     if resp.status_code not in (200, 404):
         resp.raise_for_status()
-    print(f"Removed label: {name}")
 
 
-def add_label(name):
+def add_label(repo, pr_number, name, headers):
     resp = requests.post(
-        f"{BASE_URL}/issues/{PR_NUMBER}/labels",
-        headers=HEADERS,
+        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
+        headers=headers,
         json={"labels": [name]},
     )
     resp.raise_for_status()
-    print(f"Assigned label: {name}")
 
 
 def main():
-    commits = get_commits()
+    args = parse_args()
+    headers = make_headers(args.token)
+
+    commits = get_commits(args.repo, args.pr_number, headers)
     label = determine_label(commits)
 
-    for existing in get_current_labels():
+    for existing in get_current_labels(args.repo, args.pr_number, headers):
         if existing in VERSION_LABELS:
-            remove_label(existing)
+            remove_label(args.repo, args.pr_number, existing, headers)
+            print(f"Removed label: {existing}")
 
-    if label:
-        add_label(label)
-    else:
+    if not label:
         print("No version label assigned (no versioned commits found)")
+        return
+    add_label(args.repo, args.pr_number, label, headers)
+    print(f"Assigned label: {label}")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -62,6 +62,14 @@ def get_commits(repo, pr_number, headers):
     return commits
 
 
+def _update_label(label, priority, type_):
+    if type_ == Label.FEATURE and priority > 1:
+        return Label.FEATURE, 1
+    if type_ in PATCH_TYPES and priority > 2:
+        return type_, 2
+    return label, priority
+
+
 def determine_label(commits):
     label = None
     priority = float("inf")
@@ -72,11 +80,7 @@ def determine_label(commits):
         m = TYPE_RE.match(subject)
         if not m:
             continue
-        type_ = m.group(1)
-        if type_ == Label.FEATURE and priority > 1:
-            label, priority = Label.FEATURE, 1
-        elif type_ in PATCH_TYPES and priority > 2:
-            label, priority = type_, 2
+        label, priority = _update_label(label, priority, m.group(1))
     return label
 
 

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -7,13 +7,23 @@ If no versioned commits are found, no label is assigned (no version bump).
 
 import argparse
 import re
+from enum import StrEnum
 
 import requests
 
+
+class Label(StrEnum):
+    MAJOR = "major"
+    FEATURE = "feature"
+    FIX = "fix"
+    PERFORMANCE = "performance"
+    REVERT = "revert"
+
+
 BREAKING_RE = re.compile(r"^[a-z]+(\([^)]+\))?!:")
 TYPE_RE = re.compile(r"^([a-z]+)(?:\([^)]+\))?!?:")
-PATCH_TYPES = {"fix", "performance", "revert"}
-VERSION_LABELS = {"major", "feature", "fix", "performance", "revert"}
+PATCH_TYPES = {Label.FIX, Label.PERFORMANCE, Label.REVERT}
+VERSION_LABELS = {Label.MAJOR, Label.FEATURE, Label.FIX, Label.PERFORMANCE, Label.REVERT}
 
 
 def parse_args():

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -42,11 +42,6 @@ def make_headers(token):
     }
 
 
-def _labels_url(repo, pr_number, name=None):
-    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels"
-    return f"{url}/{name}" if name else url
-
-
 def get_commits(repo, pr_number, headers):
     commits = []
     page = 1
@@ -84,20 +79,26 @@ def determine_label(commits):
 
 
 def get_current_labels(repo, pr_number, headers):
-    resp = requests.get(_labels_url(repo, pr_number), headers=headers)
+    resp = requests.get(
+        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
+        headers=headers,
+    )
     resp.raise_for_status()
     return [entry["name"] for entry in resp.json()]
 
 
 def remove_label(repo, pr_number, name, headers):
-    resp = requests.delete(_labels_url(repo, pr_number, name), headers=headers)
+    resp = requests.delete(
+        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels/{name}",
+        headers=headers,
+    )
     if resp.status_code not in (200, 404):
         resp.raise_for_status()
 
 
 def add_label(repo, pr_number, name, headers):
     resp = requests.post(
-        _labels_url(repo, pr_number),
+        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
         headers=headers,
         json={"labels": [name]},
     )

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -1,0 +1,106 @@
+"""Assigns a version label to a milestone PR based on its commits.
+
+Parses the Conventional Commits subject of each commit in the PR and assigns
+the highest-impact version label: major > feature > fix/performance/revert.
+If no versioned commits are found, no label is assigned (no version bump).
+"""
+
+import os
+import re
+import sys
+
+import requests
+
+TOKEN = os.environ["GITHUB_TOKEN"]
+REPO = os.environ["GITHUB_REPOSITORY"]
+PR_NUMBER = int(os.environ["PR_NUMBER"])
+
+HEADERS = {
+    "Authorization": f"Bearer {TOKEN}",
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+BASE_URL = f"https://api.github.com/repos/{REPO}"
+
+BREAKING_RE = re.compile(r"^[a-z]+(\([^)]+\))?!:")
+TYPE_RE = re.compile(r"^([a-z]+)(?:\([^)]+\))?!?:")
+PATCH_TYPES = {"fix", "performance", "revert"}
+VERSION_LABELS = {"major", "feature", "fix", "performance", "revert"}
+
+
+def get_commits():
+    commits = []
+    page = 1
+    while True:
+        resp = requests.get(
+            f"{BASE_URL}/pulls/{PR_NUMBER}/commits",
+            headers=HEADERS,
+            params={"per_page": 100, "page": page},
+        )
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        commits.extend(batch)
+        page += 1
+    return commits
+
+
+def determine_label(commits):
+    label = None
+    priority = float("inf")
+    for commit in commits:
+        subject = commit["commit"]["message"].split("\n")[0]
+        if BREAKING_RE.match(subject):
+            return "major"
+        m = TYPE_RE.match(subject)
+        if m:
+            type_ = m.group(1)
+            if type_ == "feature" and priority > 1:
+                label, priority = "feature", 1
+            elif type_ in PATCH_TYPES and priority > 2:
+                label, priority = type_, 2
+    return label
+
+
+def get_current_labels():
+    resp = requests.get(f"{BASE_URL}/issues/{PR_NUMBER}/labels", headers=HEADERS)
+    resp.raise_for_status()
+    return [entry["name"] for entry in resp.json()]
+
+
+def remove_label(name):
+    resp = requests.delete(
+        f"{BASE_URL}/issues/{PR_NUMBER}/labels/{name}", headers=HEADERS
+    )
+    if resp.status_code not in (200, 404):
+        resp.raise_for_status()
+    print(f"Removed label: {name}")
+
+
+def add_label(name):
+    resp = requests.post(
+        f"{BASE_URL}/issues/{PR_NUMBER}/labels",
+        headers=HEADERS,
+        json={"labels": [name]},
+    )
+    resp.raise_for_status()
+    print(f"Assigned label: {name}")
+
+
+def main():
+    commits = get_commits()
+    label = determine_label(commits)
+
+    for existing in get_current_labels():
+        if existing in VERSION_LABELS:
+            remove_label(existing)
+
+    if label:
+        add_label(label)
+    else:
+        print("No version label assigned (no versioned commits found)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -20,6 +20,8 @@ class Label(StrEnum):
     REVERT = "revert"
 
 
+GITHUB_API_URL = "https://api.github.com"
+
 BREAKING_RE = re.compile(r"^[a-z]+(\([^)]+\))?!:")
 TYPE_RE = re.compile(r"^([a-z]+)(?:\([^)]+\))?!?:")
 PATCH_TYPES = {Label.FIX, Label.PERFORMANCE, Label.REVERT}
@@ -47,7 +49,7 @@ def get_commits(repo, pr_number, headers):
     page = 1
     while True:
         resp = requests.get(
-            f"https://api.github.com/repos/{repo}/pulls/{pr_number}/commits",
+            f"{GITHUB_API_URL}/repos/{repo}/pulls/{pr_number}/commits",
             headers=headers,
             params={"per_page": 100, "page": page},
         )
@@ -80,7 +82,7 @@ def determine_label(commits):
 
 def get_current_labels(repo, pr_number, headers):
     resp = requests.get(
-        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
+        f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/labels",
         headers=headers,
     )
     resp.raise_for_status()
@@ -89,7 +91,7 @@ def get_current_labels(repo, pr_number, headers):
 
 def remove_label(repo, pr_number, name, headers):
     resp = requests.delete(
-        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels/{name}",
+        f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/labels/{name}",
         headers=headers,
     )
     if resp.status_code not in (200, 404):
@@ -98,7 +100,7 @@ def remove_label(repo, pr_number, name, headers):
 
 def add_label(repo, pr_number, name, headers):
     resp = requests.post(
-        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
+        f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/labels",
         headers=headers,
         json={"labels": [name]},
     )

--- a/.github/scripts/label-milestone-pr.py
+++ b/.github/scripts/label-milestone-pr.py
@@ -42,6 +42,11 @@ def make_headers(token):
     }
 
 
+def _labels_url(repo, pr_number, name=None):
+    url = f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels"
+    return f"{url}/{name}" if name else url
+
+
 def get_commits(repo, pr_number, headers):
     commits = []
     page = 1
@@ -79,26 +84,20 @@ def determine_label(commits):
 
 
 def get_current_labels(repo, pr_number, headers):
-    resp = requests.get(
-        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
-        headers=headers,
-    )
+    resp = requests.get(_labels_url(repo, pr_number), headers=headers)
     resp.raise_for_status()
     return [entry["name"] for entry in resp.json()]
 
 
 def remove_label(repo, pr_number, name, headers):
-    resp = requests.delete(
-        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels/{name}",
-        headers=headers,
-    )
+    resp = requests.delete(_labels_url(repo, pr_number, name), headers=headers)
     if resp.status_code not in (200, 404):
         resp.raise_for_status()
 
 
 def add_label(repo, pr_number, name, headers):
     resp = requests.post(
-        f"https://api.github.com/repos/{repo}/issues/{pr_number}/labels",
+        _labels_url(repo, pr_number),
         headers=headers,
         json={"labels": [name]},
     )

--- a/.github/workflows/label-milestone-pr.yml
+++ b/.github/workflows/label-milestone-pr.yml
@@ -1,0 +1,24 @@
+name: "Label Milestone PR"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label-milestone:
+    if: startsWith(github.head_ref, 'milestone/')
+    name: Assign version label based on commit analysis
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Determine and assign version label
+        run: python .github/scripts/label-milestone-pr.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/label-milestone-pr.yml
+++ b/.github/workflows/label-milestone-pr.yml
@@ -18,7 +18,8 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Determine and assign version label
-        run: python .github/scripts/label-milestone-pr.py
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: >-
+          python .github/scripts/label-milestone-pr.py
+          --token "${{ secrets.GITHUB_TOKEN }}"
+          --repo "${{ github.repository }}"
+          --pr-number "${{ github.event.pull_request.number }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ Develop locally. Since changes will be squash merged, commit messages during wor
 
 ### Step 4: Create a Pull Request (PR)
 Create a PR on GitHub.
-* **Title**: Must strictly follow **[Naming Convention](#5-naming-convention-and-semver-conventional-commits)** (checked by CI).
-* **Body**: Use the PR template to provide complete context. See **[PR Description Best Practices](#4-pr-description-best-practices)** below.
+* **Title**: Must strictly follow **[Naming Convention](#7-naming-convention-and-semver-conventional-commits)** (checked by CI).
+* **Body**: Use the PR template to provide complete context. See **[PR Description Best Practices](#5-pr-description-best-practices)** below.
 * **Labels**: Automatically assigned based on branch name.
     * ⚠️ **For breaking changes**: The `major` label is automatically assigned when the PR title contains `!`.
 * **Draft PRs**: If your work is not ready for review, create a Draft PR. This signals to reviewers that the code is still in progress and allows early feedback without formal review.
@@ -52,7 +52,33 @@ Create a PR on GitHub.
 
 ---
 
-## 3. Issue Description Best Practices
+## 3. Milestone Branch Workflow
+
+For projects with multiple independent concepts or large feature sets, use **milestone branches** to group related work under a single GitHub Milestone.
+
+### Structure
+
+```
+main
+└── milestone/<milestone-number>-<description>       ← one per GitHub Milestone
+    ├── feature/<issue-number>-<description>
+    └── fix/<issue-number>-<description>
+```
+
+* **`milestone-number`** is the **GitHub Milestone number**.
+* The concept or goal is written in the **GitHub Milestone's description** — not in any file on the branch.
+* Feature/fix branch naming follows the existing convention (`feature/<issue-number>-<description>`). Issue numbers are unique project-wide and are independent of milestone numbers.
+
+### Lifecycle
+
+1. **Open** a GitHub Milestone and describe the concept/goal in its description.
+2. **Create** `milestone/<milestone-number>-<description>` from `main`.
+3. **Work**: open Issues under the Milestone, create `feature/<issue-number>-...` branches from the milestone branch, and PR back into it.
+4. **Close**: when all Issues are resolved, merge the milestone branch into `main` via a PR, then close the GitHub Milestone.
+
+---
+
+## 4. Issue Description Best Practices
 
 A good issue is **self-documenting**: anyone should be able to understand it without prior context, even the author returning months later.
 
@@ -102,7 +128,7 @@ A good issue is **self-documenting**: anyone should be able to understand it wit
 
 ---
 
-## 4. PR Description Best Practices
+## 5. PR Description Best Practices
 
 A good PR tells the story of your change: not just *what* changed, but *why* it changed and *how* to verify it.
 
@@ -134,7 +160,7 @@ When your PR title includes `!` (indicating a breaking change), provide addition
 
 ---
 
-## 5. Commit Message Best Practices
+## 6. Commit Message Best Practices
 
 While this project uses **Squash & Merge** (making PR titles the final commit message), writing descriptive commit messages during development helps reviewers understand your changes and makes debugging easier.
 
@@ -217,7 +243,7 @@ Before committing, verify your message answers:
 
 ---
 
-## 6. Naming Convention and SemVer (Conventional Commits)
+## 7. Naming Convention and SemVer (Conventional Commits)
 
 Pull Request titles must follow the **Conventional Commits** format.
 
@@ -277,7 +303,7 @@ The `major` label will be automatically added when the PR is created.
 
 ---
 
-## 7. Automation Setup (for Maintainers)
+## 8. Automation Setup (for Maintainers)
 
 This project uses the following CI configurations to assist with guideline compliance:
 
@@ -287,7 +313,7 @@ This project uses the following CI configurations to assist with guideline compl
 
 ---
 
-## 8. Release Process
+## 9. Release Process
 
 This project uses **[Release Drafter](https://github.com/release-drafter/release-drafter)** to semi-automate the release process.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,7 @@ main
 * **`milestone-number`** is the **GitHub Milestone number**.
 * The concept or goal is written in the **GitHub Milestone's description** — not in any file on the branch.
 * Feature/fix branch naming follows the existing convention (`feature/<issue-number>-<description>`). Issue numbers are unique project-wide and are independent of milestone numbers.
+* **Exception to [Section 2](#2-development-workflow)**: when using a milestone branch, feature/fix branches are created from the milestone branch — not from `main`.
 
 ### Lifecycle
 
@@ -75,6 +76,7 @@ main
 2. **Create** `milestone/<milestone-number>-<description>` from `main`.
 3. **Work**: open Issues under the Milestone, create `feature/<issue-number>-...` branches from the milestone branch, and PR back into it.
 4. **Close**: when all Issues are resolved, merge the milestone branch into `main` via a PR, then close the GitHub Milestone.
+    * ⚠️ The `milestone/...` branch prefix is not matched by the auto-labeler. Add the appropriate SemVer label manually (`major`, `feature`, `fix`, etc.) before merging so release automation works correctly.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,6 @@ main
 * **`milestone-number`** is the **GitHub Milestone number**.
 * The concept or goal is written in the **GitHub Milestone's description** — not in any file on the branch.
 * Feature/fix branch naming follows the existing convention (`feature/<issue-number>-<description>`). Issue numbers are unique project-wide and are independent of milestone numbers.
-* **Exception to [Section 2](#2-development-workflow)**: when using a milestone branch, feature/fix branches are created from the milestone branch — not from `main`.
 
 ### Lifecycle
 
@@ -76,7 +75,6 @@ main
 2. **Create** `milestone/<milestone-number>-<description>` from `main`.
 3. **Work**: open Issues under the Milestone, create `feature/<issue-number>-...` branches from the milestone branch, and PR back into it.
 4. **Close**: when all Issues are resolved, merge the milestone branch into `main` via a PR, then close the GitHub Milestone.
-    * ⚠️ The `milestone/...` branch prefix is not matched by the auto-labeler. Add the appropriate SemVer label manually (`major`, `feature`, `fix`, etc.) before merging so release automation works correctly.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,16 +19,18 @@ When you find a task or bug, create an Issue. Choose the appropriate template:
 
 ### Step 2: Create a Branch
 Create a working branch from `main`.
-**Naming convention: `prefix/issue-number-description`**
+**Naming convention: `prefix/<issue-number>-<description>`**
 
 * **prefix**: Corresponds to the Type (see below): `feature/`, `fix/`, `documentation/`, etc.
-* **issue-number**: The corresponding Issue number (required)
-* **description**: Brief description in kebab-case (lowercase letters and hyphens)
+* **`<issue-number>`**: The corresponding Issue number (required)
+* **`<description>`**: Brief description in kebab-case (lowercase letters and hyphens)
 
 **Good examples:**
 * ✅ `feature/123-login-page` (Login feature for Issue #123)
 * ✅ `fix/45-auth-token-bug` (Bug fix for Issue #45)
 * ✅ `documentation/67-api-guide` (Documentation update for Issue #67)
+
+> **Exception**: When organizing work under a Milestone, create feature/fix branches from the milestone branch instead of `main`. See [Section 3: Milestone Branch Workflow](#3-milestone-branch-workflow).
 
 ### Step 3: Implementation & Push
 Develop locally. Since changes will be squash merged, commit messages during work are flexible (e.g., `wip`, `fix`).
@@ -39,6 +41,7 @@ Create a PR on GitHub.
 * **Body**: Use the PR template to provide complete context. See **[PR Description Best Practices](#5-pr-description-best-practices)** below.
 * **Labels**: Automatically assigned based on branch name.
     * ⚠️ **For breaking changes**: The `major` label is automatically assigned when the PR title contains `!`.
+    * ⚠️ **For milestone branches**: The version label (`major`, `feature`, `fix`, etc.) is automatically determined by CI, which analyzes the commits included in the milestone branch.
 * **Draft PRs**: If your work is not ready for review, create a Draft PR. This signals to reviewers that the code is still in progress and allows early feedback without formal review.
 
 ### Step 5: Review & Merge
@@ -74,7 +77,7 @@ main
 1. **Open** a GitHub Milestone and describe the concept/goal in its description.
 2. **Create** `milestone/<milestone-number>-<description>` from `main`.
 3. **Work**: open Issues under the Milestone, create `feature/<issue-number>-...` branches from the milestone branch, and PR back into it.
-4. **Close**: when all Issues are resolved, merge the milestone branch into `main` via a PR, then close the GitHub Milestone.
+4. **Close**: when all Issues are resolved, open a PR from the milestone branch into `main`. CI automatically assigns the version label by analyzing the commits in the milestone branch. After merge, close the GitHub Milestone.
 
 ---
 


### PR DESCRIPTION
## Related Issue

Closes #105

## Context

Projects with multiple independent concepts need a way to group feature work under a single GitHub Milestone. The current guideline only describes a flat model where all branches come from `main`. This PR adds a dedicated section documenting the milestone branch strategy.

## Changes

- Added **Section 3: Milestone Branch Workflow** defining branch naming (`milestone/<milestone-number>-<description>`), the rule that the concept/goal lives in the GitHub Milestone description (not in branch files), and the full lifecycle.
- Renumbered all subsequent sections (4→4 unchanged, old 4 PR Practices→5, old 5 Commit→6, old 6 Naming→7, old 7 Automation→8, old 8 Release→9).
- Updated two internal anchor links in Section 2 to point to the new section numbers.

## Type of Change

- [x] Documentation update

## Test Steps

1. Open `CONTRIBUTING.md` on this branch.
2. Confirm Section 3 "Milestone Branch Workflow" is present and complete.
3. Confirm sections 4–9 are sequential with no gaps or duplicates.
4. Click the internal links in Section 2 ("Naming Convention" and "PR Description Best Practices") and confirm they resolve correctly.

## Checklist

- [x] Section numbering is sequential (1–9)
- [x] Internal anchor links updated
- [x] `Closes #105` included